### PR TITLE
Add module to add/remove database to availability group

### DIFF
--- a/plugins/modules/database_ag.ps1
+++ b/plugins/modules/database_ag.ps1
@@ -54,10 +54,16 @@ try {
         $databases = $existingAg.AvailabilityDatabases | Select-Object Name
         if ($databases.Name -contains $database) {
             try {
-                $output = Remove-DbaAgDatabase -SqlInstance $primaryNode - SqlCredential $sqlCredential `
-                    -AvailabilityGroup $existingAg `
-                    -Database $database `
-                    -EnableException -Confirm:$false
+                $removeAgDatabaseSplat = @{
+                    SqlInstance = $primaryNode
+                    SqlCredential = $sqlCredential
+                    AvailabilityGroup = $existingAg
+                    Database = $database
+                    WhatIf = $checkMode
+                    EnableException = $true
+                    Confirm = $false
+                }
+                $output = Remove-DbaAgDatabase @removeAgDatabaseSplat
 
                 if ($output.Status -eq "Removed") {
                     $module.Result.changed = $true
@@ -75,11 +81,18 @@ try {
     }
     elseif ($state -eq "present") {
         try {
-            $output = Add-DbaAgDatabase -SqlInstance $primaryNode - SqlCredential $sqlCredential `
-                -Secondary $secondaryNode -SecondarySqlCredential $sqlCredential `
-                -AvailabilityGroup $existingAg `
-                -Database $database `
-                -EnableException -Confirm:$false
+            $addAgDatabaseSplat = @{
+                SqlInstance = $primaryNode
+                SqlCredential = $sqlCredential
+                Secondary = $secondaryNode
+                SecondarySqlCredential = $sqlCredential
+                AvailabilityGroup = $existingAg
+                Database = $database
+                WhatIf = $checkMode
+                EnableException = $true
+                Confirm = $false
+            }
+            $output = Add-DbaAgDatabase @addAgDatabaseSplat
             $module.Result.changed = $true
         }
         catch {

--- a/plugins/modules/database_ag.ps1
+++ b/plugins/modules/database_ag.ps1
@@ -42,11 +42,6 @@ try {
     try {
         $server = Connect-DbaInstance -SqlInstance $sqlInstance -SqlCredential $sqlCredential
         $existingAg = $server | Get-DbaAvailabilityGroup -AvailabilityGroup $availabilityGroup -EnableException
-        $existingListener = $existingAg.AvailabilityGroupListeners
-        $existingAgReplicas = Get-DbaAgReplica -SqlInstance $existingListener.Name -SqlCredential $sqlCredential -AvailabilityGroup $availabilityGroup
-
-        $primaryNode = ($existingAgReplicas | Where-Object role -eq 'Primary').Name
-        $secondaryNode = ($existingAgReplicas | Where-Object role -eq 'Secondary').Name
     }
     catch {
         $module.FailJson("Error checking availability group status.", $_.Exception.Message)
@@ -57,7 +52,7 @@ try {
         if ($databases.Name -contains $database) {
             try {
                 $removeAgDatabaseSplat = @{
-                    SqlInstance = $primaryNode
+                    SqlInstance = $sqlInstance
                     SqlCredential = $sqlCredential
                     AvailabilityGroup = $availabilityGroup
                     Database = $database
@@ -84,10 +79,8 @@ try {
     elseif ($state -eq "present") {
         try {
             $addAgDatabaseSplat = @{
-                SqlInstance = $primaryNode
+                SqlInstance = $sqlInstance
                 SqlCredential = $sqlCredential
-                Secondary = $secondaryNode
-                SecondarySqlCredential = $sqlCredential
                 AvailabilityGroup = $availabilityGroup
                 Database = $database
                 WhatIf = $checkMode

--- a/plugins/modules/database_ag.ps1
+++ b/plugins/modules/database_ag.ps1
@@ -16,8 +16,7 @@ $spec = @{
     options = @{
         username = @{type = 'str'; required = $false }
         password = @{type = 'str'; required = $false; no_log = $true }
-        enabled = @{type = 'bool'; required = $false; default = $true }
-        force = @{type = 'bool'; required = $false; default = $false }
+        database = @{type = 'str'; required = $true }
         state = @{type = 'str'; required = $false; default = 'present'; choices = @('present', 'absent') }
     }
     required_together = @(
@@ -31,8 +30,8 @@ if ($null -ne $Module.Params.username) {
     [securestring]$secPassword = ConvertTo-SecureString $Module.Params.password -AsPlainText -Force
     [pscredential]$credential = New-Object System.Management.Automation.PSCredential ($Module.Params.username, $secPassword)
 }
-$enabled = $module.Params.enabled
-$force = $module.Params.force
+$database = $module.Params.database
+$state = $module.Params.state
 $checkMode = $module.CheckMode
 $module.Result.changed = $false
 

--- a/plugins/modules/database_ag.ps1
+++ b/plugins/modules/database_ag.ps1
@@ -1,0 +1,89 @@
+#!powershell
+# -*- coding: utf-8 -*-
+
+# (c) 2022, John McCall (@lowlydba)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell ansible_collections.lowlydba.sqlserver.plugins.module_utils._SqlServerUtils
+#Requires -Modules @{ ModuleName="dbatools"; ModuleVersion="2.0.0" }
+
+$ErrorActionPreference = "Stop"
+
+# Get Csharp utility module
+$spec = @{
+    supports_check_mode = $true
+    options = @{
+        username = @{type = 'str'; required = $false }
+        password = @{type = 'str'; required = $false; no_log = $true }
+        enabled = @{type = 'bool'; required = $false; default = $true }
+        force = @{type = 'bool'; required = $false; default = $false }
+        state = @{type = 'str'; required = $false; default = 'present'; choices = @('present', 'absent') }
+    }
+    required_together = @(
+        , @('username', 'password')
+    )
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec, @(Get-LowlyDbaSqlServerAuthSpec))
+$sqlInstance, $sqlCredential = Get-SqlCredential -Module $module
+if ($null -ne $Module.Params.username) {
+    [securestring]$secPassword = ConvertTo-SecureString $Module.Params.password -AsPlainText -Force
+    [pscredential]$credential = New-Object System.Management.Automation.PSCredential ($Module.Params.username, $secPassword)
+}
+$enabled = $module.Params.enabled
+$force = $module.Params.force
+$checkMode = $module.CheckMode
+$module.Result.changed = $false
+
+try {
+    # Get availability group status
+    try {
+        $server = Connect-DbaInstance -SqlInstance $sqlInstance -SqlCredential $sqlCredential
+        $existingAg = $server | Get-DbaAvailabilityGroup -EnableException
+        $existingListener = $existingAg.AvailabilityGroupListeners
+        $existingAgReplicas = Get-DbaAgReplica -SqlInstance $existingListener.Name -SqlCredential $sqlCredential -AvailabilityGroup $existingAg.AvailabilityGroup
+        $output = $existingAg
+    }
+    catch {
+        $module.FailJson("Error checking availability group status.", $_.Exception.Message)
+    }
+
+    if ($state -eq "absent") {
+        $databases = $existingAg.AvailabilityDatabases | Select-Object Name
+        if ($databases.Name -contains $database) {
+            try {
+                $primaryNode = ($agReplicas | Where-Object role -eq 'Primary').Name
+                $output = Remove-DbaAgDatabase -SqlInstance $primaryNode - SqlCredential $sqlCredential `
+                    -AvailabilityGroup $existingAg.AvailabilityGroup `
+                    -Database $database `
+                    -EnableException -Confirm:$false
+                $module.Result.changed = $true
+            }
+            catch {
+                $module.FailJson("An exception occurred while trying to remove database [$database] from AG [$existingAg.AvailabilityGroup].", $_)
+            }
+        }
+
+        $module.ExitJson()
+    }
+    elseif ($state -eq "present") {
+        $primaryNode = ($agReplicas | Where-Object role -eq 'Primary').Name
+        $secondaryNode = ($agReplicas | Where-Object role -eq 'Secondary').Name
+        $output = Add-DbaAgDatabase -SqlInstance $primaryNode - SqlCredential $sqlCredential `
+            -Secondary $secondaryNode -SecondarySqlCredential $sqlCredential `
+            -AvailabilityGroup $existingAg.AvailabilityGroup `
+            -Database $database `
+            -EnableException -Confirm:$false
+        $module.Result.changed = $true
+    }
+
+    if ($null -ne $output) {
+        $resultData = ConvertTo-SerializableObject -InputObject $output
+        $module.Result.data = $resultData
+    }
+    $module.ExitJson()
+}
+catch {
+    $module.FailJson("Error configuring AG database.", $_)
+}

--- a/plugins/modules/database_ag.ps1
+++ b/plugins/modules/database_ag.ps1
@@ -45,8 +45,8 @@ try {
         $existingListener = $existingAg.AvailabilityGroupListeners
         $existingAgReplicas = Get-DbaAgReplica -SqlInstance $existingListener.Name -SqlCredential $sqlCredential -AvailabilityGroup $availabilityGroup
 
-        $primaryNode = ($agReplicas | Where-Object role -eq 'Primary').Name
-        $secondaryNode = ($agReplicas | Where-Object role -eq 'Secondary').Name
+        $primaryNode = ($existingAgReplicas | Where-Object role -eq 'Primary').Name
+        $secondaryNode = ($existingAgReplicas | Where-Object role -eq 'Secondary').Name
     }
     catch {
         $module.FailJson("Error checking availability group status.", $_.Exception.Message)

--- a/plugins/modules/database_ag.py
+++ b/plugins/modules/database_ag.py
@@ -17,6 +17,11 @@ options:
       - Name of the target database.
     type: str
     required: true
+  availability_group:
+    description:
+      - Name of the availability group.
+    type: str
+    required: true
   username:
     description:
       - Username for alternative credential to authenticate with Windows.
@@ -42,6 +47,7 @@ EXAMPLES = r'''
   lowlydba.sqlserver.database_ag:
     sql_instance: sql-01.myco.io
     database: LowlyDB
+    availability_group: AG01
     state: present
 '''
 

--- a/plugins/modules/database_ag.py
+++ b/plugins/modules/database_ag.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2022, John McCall (@lowlydba)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: hadr
+short_description: Add/remove database to/from availability group
+description:
+  - Add or remove a database to/from a given availability group.
+version_added: 0.4.0
+options:
+  database:
+    description:
+      - Name of the target database.
+    type: str
+    required: true
+  username:
+    description:
+      - Username for alternative credential to authenticate with Windows.
+    type: str
+    required: false
+  password:
+    description:
+      - Password for alternative credential to authenticate with Windows.
+    type: str
+    required: false
+author: "John McCall (@lowlydba)"
+requirements:
+  - L(dbatools,https://www.powershellgallery.com/packages/dbatools/) PowerShell module
+extends_documentation_fragment:
+  - lowlydba.sqlserver.sql_credentials
+  - lowlydba.sqlserver.attributes.check_mode
+  - lowlydba.sqlserver.attributes.platform_win
+  - lowlydba.sqlserver.state
+'''
+
+EXAMPLES = r'''
+- name: Add database to availability group
+  lowlydba.sqlserver.database_ag:
+    sql_instance: sql-01.myco.io
+    database: LowlyDB
+    state: present
+'''
+
+RETURN = r'''
+data:
+  description:
+    - Output from the C(Add-DbaAgDatabase) or C(Remove-DbaAgDatabase) function.
+  returned: success, but not in check_mode.
+  type: dict
+'''


### PR DESCRIPTION
The new module accepts a database name and an availability group name and tries to add or remove it from the AG. For example:

```
- name: Add database to availability group
  lowlydba.sqlserver.database_ag:
    sql_instance: sql-01.myco.io
    database: LowlyDB
    availability_group: AG01
    state: present
```