### PR TITLE
Add new module to execute SQL queries

### DIFF
--- a/plugins/modules/query.ps1
+++ b/plugins/modules/query.ps1
@@ -1,0 +1,84 @@
+#!powershell
+# -*- coding: utf-8 -*-
+
+# (c) 2022, John McCall (@lowlydba)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell ansible_collections.lowlydba.sqlserver.plugins.module_utils._SqlServerUtils
+#Requires -Modules @{ ModuleName="dbatools"; ModuleVersion="2.0.0" }
+
+$ErrorActionPreference = "Stop"
+
+# Get Csharp utility module
+$spec = @{
+    supports_check_mode = $true
+    options = @{
+        database = @{type = 'str'; required = $true }
+        query = @{type = 'str'; required = $true }
+        query_timeout = @{type = 'int'; required = $false; default = 60 }
+        messages_to_output = @{type = 'bool'; required = $false; default = $false}
+    }
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec, @(Get-LowlyDbaSqlServerAuthSpec))
+$sqlInstance, $sqlCredential = Get-SqlCredential -Module $module
+$database = $module.Params.database
+$query = $module.Params.query
+$messagesToOutput = $module.Params.messages_to_output
+$queryTimeout = $module.Params.query_timeout
+$checkMode = $module.CheckMode
+
+$module.Result.changed = $false
+
+try {
+    $invokeQuerySplat = @{
+        SqlInstance = $sqlInstance
+        SqlCredential = $sqlCredential
+        Database = $database
+        Query = $query
+        QueryTimeout = $queryTimeout
+        As = "PSObject"
+        MessagesToOutput = $messagesToOutput
+        EnableException = $true
+    }
+    if ($checkMode) {
+        $invokeQuerySplat.Add("NoExec", $true)
+    }
+
+    $result = Invoke-DbaQuery @invokeQuerySplat
+    $completionTime = Get-Date
+
+    $data, $messages = @(), @()
+
+    if ($null -eq $result.Count) {
+        $data += $result[0]
+    } else {
+        if ($result.Count -gt 0) {
+            for ($i = 0; $i -lt $result.Count; $i++) {
+                if ($messagesToOutput -and $result[$i].GetType().Name -eq "String") {
+                    $messages += $result[$i]
+                } else {
+                    $data += $result[$i]
+                }
+            }
+        }
+    }
+
+    $outputSplat = [PSCustomObject]@{
+        results = $data
+        messages = $messages
+        completion_time = $completionTime
+    }
+
+    if ($null -ne $outputSplat) {
+        $resultData = ConvertTo-SerializableObject -InputObject $outputSplat
+        $module.Result.data = $resultData
+    }
+
+    $module.Result.changed = $true
+    $module.ExitJson()
+}
+catch {
+    $module.FailJson("Executing query failed.", $_)
+}

--- a/plugins/modules/query.py
+++ b/plugins/modules/query.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2022, John McCall (@lowlydba)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: query
+short_description: Executes a generic query
+description:
+  - Execute a query against a database. Does not return a resultset. Ideal for ad-hoc configurations or DML queries.
+version_added: 0.1.0
+options:
+  database:
+    description:
+      - Name of the database to execute the query in.
+    type: str
+    required: true
+  query:
+    description:
+      - The query to be executed.
+    type: str
+    required: true
+  query_timeout:
+    description:
+      - Number of seconds to wait before timing out the query execution.
+    type: int
+    required: false
+    default: 60
+  messages_to_output:
+    description:
+      - Add output stream messages to the result object.
+    type: bool
+    required: false
+    default: false
+author: "John McCall (@lowlydba)"
+requirements:
+  - L(dbatools,https://www.powershellgallery.com/packages/dbatools/) PowerShell module
+extends_documentation_fragment:
+  - lowlydba.sqlserver.sql_credentials
+  - lowlydba.sqlserver.attributes.check_mode
+  - lowlydba.sqlserver.attributes.platform_all
+'''
+
+EXAMPLES = r'''
+- name: Select all users
+  lowlydba.sqlserver.query:
+    sql_instance: sql-01-myco.io
+    database: userdb
+    query: "SELECT * FROM dbo.User;"
+'''
+
+RETURN = r'''
+data:
+  description: Modified output from the C(Invoke-DbaQuery) function.
+  returned: success, but not in check_mode.
+  type: dict
+'''


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
For some of the tasks in the second package, we need to execute SELECT queries on the cluster and process the results. The existing nonquery module is meant to be used with non-read queries, where the query results are basically ignored.

This new module is able to execute any query and tries to parse the results and format them into something that Ansible can understand.

The following task:

```yaml
tasks:
    - name: 'Run select query'
      lowlydba.sqlserver.query:
        sql_instance: '{{ ansible_host }}'
        sql_username: '{{ mssql.sa_user }}'
        sql_password: 'C!sco123'
        query: "PRINT 'HELLO'; PRINT 'GOODBYE'; select * from dbo.dbaas_test_data;"
        database: 'dbtest1'
        messages_to_output: true
      when: cluster and primary_node
```
Returns the following:

```
changed: [dbaas08] => {
    "changed": true,
    "data": {
        "completion_time": "2024-03-28T14:03:37.1647770+01:00",
        "messages": [
            "HELLO",
            "GOODBYE"
        ],
        "results": [
            {
                "id": 1,
                "name": "Pepito"
            },
            {
                "id": 2,
                "name": "Manolito"
            },
            {
                "id": 3,
                "name": "Fulanito"
            },
            {
                "id": 4,
                "name": "Menganito"
            },
            {
                "id": 5,
                "name": "John Doe"
            }
        ]
    },
    "invocation": {
        "module_args": {
            "database": "dbtest1",
            "messages_to_output": true,
            "query": "PRINT 'HELLO'; PRINT 'GOODBYE'; select * from dbo.dbaas_test_data;",
            "query_timeout": 60,
            "sql_instance": "dbaas08.cytech.local",
            "sql_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "sql_username": "sa"
        }
    }
}
```
