### PR TITLE
Add database role permission module

### DIFF
--- a/plugins/modules/database_role.py
+++ b/plugins/modules/database_role.py
@@ -6,10 +6,10 @@
 
 DOCUMENTATION = r'''
 ---
-module: server_role
-short_description: Creates a server role
+module: database_role
+short_description: Creates a database role
 description:
-  - Creates a server role.
+  - Creates a database role.
 version_added: 0.4.0
 options:
   database:
@@ -19,7 +19,7 @@ options:
     required: true
   role_name:
     description:
-      - Name of the server role.
+      - Name of the database role.
     type: str
     required: true
   owner_name:
@@ -39,7 +39,7 @@ extends_documentation_fragment:
 
 EXAMPLES = r'''
 - name: Add database role
-  lowlydba.sqlserver.server_role:
+  lowlydba.sqlserver.database_role:
     sql_instance: sql-01.myco.io
     database: LOWLYDB
     role_name: mydbrole

--- a/plugins/modules/database_role_permission.ps1
+++ b/plugins/modules/database_role_permission.ps1
@@ -1,0 +1,131 @@
+#!powershell
+# -*- coding: utf-8 -*-
+
+# (c) 2024, Daniel Gutierrez (@gutizar)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell ansible_collections.lowlydba.sqlserver.plugins.module_utils._SqlServerUtils
+#Requires -Modules @{ ModuleName="dbatools"; ModuleVersion="2.0.0" }
+
+$ErrorActionPreference = "Stop"
+
+$permissionList = @(
+    'ALTER',
+    'CONTROL',
+    'DELETE',
+    'EXECUTE',
+    'INSERT',
+    'RECEIVE',
+    'REFERENCES',
+    'SELECT',
+    'TAKE OWNERSHIP',
+    'UPDATE',
+    'VIEW CHANGE TRACKING',
+    'VIEW DEFINITION'
+)
+
+# Get Csharp utility module
+$spec = @{
+    supports_check_mode = $true
+    options = @{
+        database = @{type = 'str'; required = $true }
+        role_name = @{type = 'str'; required = $true }
+        permission = @{type = 'str'; required = $true; choices = $permissionList}
+        action = @{type = 'str'; required = $false; default = 'grant'; choices = @('grant', 'deny', 'revoke') }
+    }
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec, @(Get-LowlyDbaSqlServerAuthSpec))
+$sqlInstance, $sqlCredential = Get-SqlCredential -Module $module
+$database = $module.Params.database
+$roleName = $module.Params.role_name
+$permission = $module.Params.permission
+$action = $module.Params.action
+$module.Result.changed = $false
+
+try {
+    # Fetch existing permission in database role.
+    try {
+        $server = Connect-DbaInstance -SqlInstance $sqlInstance -SqlCredential $sqlCredential
+        $existingPermissionQuery = @(
+            "SELECT pe.permission_name, pe.state_desc, pe.class_desc, OBJECT_NAME(pe.major_id) AS object_name"
+            "FROM sys.database_principals dp"
+            "JOIN sys.database_permissions pe ON pe.grantee_principal_id = dp.principal_id"
+            "WHERE dp.name = '$roleName' AND pe.permission_name = '$permission'"
+        ) -join " "
+        $existingPermission = $server | Invoke-DbaQuery -Database $database -Query $existingPermissionQuery -As PSObject
+    }
+    catch {
+        $module.FailJson("Error checking database role permission status.", $_.Exception.Message)
+    }
+
+    if ($action -eq "revoke") {
+        # Revoke permission.
+        if ($null -ne $existingPermission) {
+            try {
+                $revokePermissionSplat = @{
+                    SqlInstance = $sqlInstance
+                    SqlCredential = $sqlCredential
+                    Database = $database
+                    Query = "REVOKE $permission TO $roleName"
+                    MessagesToOutput = $true
+                    EnableException = $true
+                }
+                $output = Invoke-DbaQuery @revokePermissionSplat
+                $module.Result.changed = $true
+            }
+            catch {
+                $module.FailJson("Revoking permission [$permission] from database role [$roleName] failed.", $_)
+            }
+        }
+    }
+    elseif ($action -eq "deny") {
+        # Deny permission from role.
+        if ($null -eq $existingPermission -or $existingPermission.state_desc -eq "GRANT") {
+            try {
+                $denyPermissionSplat = @{
+                    SqlInstance = $sqlInstance
+                    SqlCredential = $sqlCredential
+                    Database = $database
+                    Query = "DENY $permission TO $roleName"
+                    MessagesToOutput = $true
+                    EnableException = $true
+                }
+                $output = Invoke-DbaQuery @denyPermissionSplat
+                $module.Result.changed = $true
+            }
+            catch {
+                $module.FailJson("Denying permission [$permission] to database role [$roleName] failed.", $_)
+            }
+        }
+    }
+    elseif ($action -eq "grant") {
+        if ($null -eq $existingPermission -or $existingPermission.state_desc -eq "DENY") {
+            try {
+                $grantPermissionSplat = @{
+                    SqlInstance = $sqlInstance
+                    SqlCredential = $sqlCredential
+                    Database = $database
+                    Query = "GRANT $permission TO $roleName"
+                    MessagesToOutput = $true
+                    EnableException = $true
+                }
+                $output = Invoke-DbaQuery @grantPermissionSplat
+                $module.Result.changed = $true
+            }
+            catch {
+                $module.FailJson("Granting permission [$permission] to database role [$roleName] failed.", $_)
+            }
+        }
+    }
+
+    if ($null -ne $output) {
+        $resultData = ConvertTo-SerializableObject -InputObject $output
+        $module.Result.data = $resultData
+    }
+    $module.ExitJson()
+}
+catch {
+    $module.FailJson("Error modifying permissions for database role.", $_)
+}

--- a/plugins/modules/database_role_permission.ps1
+++ b/plugins/modules/database_role_permission.ps1
@@ -68,7 +68,7 @@ try {
                     SqlInstance = $sqlInstance
                     SqlCredential = $sqlCredential
                     Database = $database
-                    Query = "REVOKE $permission TO $roleName"
+                    Query = "REVOKE $permission FROM $roleName"
                     MessagesToOutput = $true
                     EnableException = $true
                 }

--- a/plugins/modules/database_role_permission.py
+++ b/plugins/modules/database_role_permission.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2024, Daniel Gutierrez (@gutizar)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: database_role_permission
+short_description: Modifies the permissions for a database role
+description:
+  - Modifies the permissions for a database role.
+version_added: 0.4.0
+options:
+  database:
+    description:
+      - Name of the target database.
+    type: str
+    required: true
+  role_name:
+    description:
+      - Name of the server role.
+    type: str
+    required: true
+  permission:
+    description:
+      - Name of the permission to modify.
+    type: str
+    required: true
+  action:
+    description:
+      - Action to permform on the permission. Either grant, deny or revoke.
+    type: str
+    required: false
+    default: grant
+author: "Daniel Gutierrez (@gutizar)"
+requirements:
+  - L(dbatools,https://www.powershellgallery.com/packages/dbatools/) PowerShell module
+extends_documentation_fragment:
+  - lowlydba.sqlserver.sql_credentials
+  - lowlydba.sqlserver.attributes.platform_win
+'''
+
+EXAMPLES = r'''
+- name: Grant ALTER to role mydbrole
+  lowlydba.sqlserver.database_role_permission:
+    sql_instance: sql-01.myco.io
+    database: LOWLYDB
+    role_name: mydbrole
+    action: grant
+'''
+
+RETURN = r''''''

--- a/plugins/modules/query.ps1
+++ b/plugins/modules/query.ps1
@@ -1,7 +1,7 @@
 #!powershell
 # -*- coding: utf-8 -*-
 
-# (c) 2022, John McCall (@lowlydba)
+# (c) 2024, Daniel Gutierrez (@gutizar)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic

--- a/plugins/modules/query.py
+++ b/plugins/modules/query.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2022, John McCall (@lowlydba)
+# (c) 2024, Daniel Gutierrez (@gutizar)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 DOCUMENTATION = r'''
@@ -34,7 +34,7 @@ options:
     type: bool
     required: false
     default: false
-author: "John McCall (@lowlydba)"
+author: "Daniel Gutierrez (@gutizar)"
 requirements:
   - L(dbatools,https://www.powershellgallery.com/packages/dbatools/) PowerShell module
 extends_documentation_fragment:


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
The current PR adds a new module to modify the database role permissions. It pretty much follows Tomaž logic and grants, denies or revokes a specific permission from a role. Looping can be used in Ansible if multiple roles/permissions must be modified.

```yaml
tasks:
    - name: 'Modify role permission'
      lowlydba.sqlserver.database_role_permission:
        sql_instance: '{{ ansible_host }}'
        sql_username: '{{ mssql.sa_user }}'
        sql_password: 'C!sco123'
        database: 'dbtest1'
        role_name: 'testdbrole1'
        permission: 'ALTER'
        state: 'revoke'
      when: cluster and primary_node
```
